### PR TITLE
Remove stale label from the PR after closing

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -98,6 +98,7 @@ jobs:
               else
                 gh pr edit "$PR_NUMBER" --add-label "auto-closed" || true
                 gh pr close "$PR_NUMBER" || echo "Failed to close PR #$PR_NUMBER"
+                gh pr edit "$PR_NUMBER" --remove-label "stale" || true
               fi
             fi
           done


### PR DESCRIPTION
## Summary
<!-- Short description of what this PR does -->

## Changes
- [ ] Data / EDA
- [ ] Feature engineering
- [ ] Modeling
- [x] Infra / CI / tooling
- [ ] Docs / README

## Screenshots / Outputs (if applicable)
<!-- Plots, metrics, or logs that show results -->

## Checklist
- [x] Code runs locally (followed README setup & test steps)
- [x] No large files committed (`data/`, `models/`, `mlruns/`)
- [x] Lint & format checks pass (`uv run black . && uv run ruff .`)
- [ ] README/docs updated if needed
